### PR TITLE
Allow user add directive on parent element of input

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,14 @@ angular.module('myApp', ['angular-mailcheck']);
 <input type="email" mailcheck>
 ```
 
+... or add on parent element of input
+
+```html
+<div mailcheck>
+  <input type="email">
+</div>
+```
+
 You can add suggestion and nope texts as strings:
 
 ```html

--- a/angular-mailcheck.js
+++ b/angular-mailcheck.js
@@ -25,10 +25,12 @@
 
         // Limit to input element of specific types
         var inputTypes = /text|email/i;
+        var inputElm = el;
+
         if(el[0].nodeName !== 'INPUT') {
-          throw new Error('angular-mailcheck is limited to input elements');
+          inputElm = el.find('input');
         }
-        if(!inputTypes.test(attrs.type)) {
+        if(!inputTypes.test(inputElm.attr('type'))) {
           throw new Error('Invalid input type for angular-mailcheck: ' + attrs.type);
         }
 
@@ -50,13 +52,14 @@
             '<a ng-bind="suggestion" ng-click="useSuggestion()"></a>? ' +
             '<a ng-click="suggestion=false; bugmenot=true">{{ nopeText }}</a>' +
           '</div>')(scope);
+
         el.after(template);
 
-        el.bind('input', function() {
+        inputElm.bind('input', function() {
             scope.suggestion = false;
           })
           .bind('blur', function() {
-            el.mailcheck({
+            inputElm.mailcheck({
               suggested: function(element, suggestion) {
                 scope.suggestion = suggestion.full;
                 scope.$apply();
@@ -68,7 +71,7 @@
           });
 
         scope.useSuggestion = function() {
-          el.val(scope.suggestion);
+          inputElm.val(scope.suggestion);
           scope.suggestion = false;
         };
 


### PR DESCRIPTION
I think it is useful if user can add directive `mailcheck` on parent of input. For example:

```
<div class="list-group list-group-sm">
    <div class="list-group-item  has-feedback m-b" mailcheck>
        <input type="email" placeholder="Email" class="form-control no-border" ng-model="loginData.userName" required/>
        <i class="glyphicon glyphicon-envelope form-control-feedback text-gray"></i>
    </div>

    <div class="list-group-item  has-feedback m-b-xs">
        <input type="password" placeholder="Password" class="form-control no-border" ng-model="loginData.password" required />
        <i class="glyphicon glyphicon-lock form-control-feedback text-gray"></i>
    </div>
</div>
```